### PR TITLE
Update understanding-word-vectors.ipynb

### DIFF
--- a/understanding-word-vectors.ipynb
+++ b/understanding-word-vectors.ipynb
@@ -22,6 +22,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "pd.set_option('max_rows', 25)\n",
+    "#if there is any error, you can write this: \"pd.set_option('display.max_rows', 25)\"\n",
     "plt.style.use('ggplot')\n",
     "plt.rcParams[\"figure.figsize\"] = (10, 4)"
    ]


### PR DESCRIPTION
I encountered an OptionError while attempting to set an option using pd.set_option(). The error message indicated that the pattern 'max_rows' matched multiple keys in the pandas options. To resolve this, I modified the code and replaced 'max_rows' with the complete option name 'display.max_rows'. This change ensured that the intended option was set correctly. Here's the updated code that resolved the error:

pd.set_option('display.max_rows', 25)

By specifying 'display.max_rows', I explicitly set the maximum number of rows to be displayed in pandas DataFrames to 25. It's important to consult the documentation for the specific version of pandas being used to verify the correct option names and syntax.

Remember, it's essential to check the documentation for the specific version of pandas you are using to ensure the correct option names and syntax.